### PR TITLE
Separate variable files per site

### DIFF
--- a/group-vars/africa-grid.yml
+++ b/group-vars/africa-grid.yml
@@ -1,6 +1,6 @@
 ---
 # Basic variables used through all roles
-
+site_name: africa-grid
 # Login name of Perun user
 perun_login: 'perun'
 # Group name of Perun user
@@ -8,10 +8,11 @@ perun_group: 'perun'
 # Full name of Perun user
 perun_name: 'Perun'
 # Email address of admin of Perun server
-perun_admin: 'admin@perun-test-domain.com'
+perun_admin: 'perun@africa-grid.org'
 
 # Address of your Perun server
-perun_address: '192.168.56.20'
+# this should be obtained as a lookup
+perun_address: '151.97.41.47'
 
 # Path to repository with cloned Perun sources from GIT
 perun_folder: "/home/{{ perun_login }}/perun-sources/"
@@ -44,4 +45,3 @@ ldap_certificate_key_file: "{{ apache_certificate_key_file }}"
 ojdbc7_file_path: '~/ojdbc7.jar'
 # Path to orai18n file on your system with Ansible
 orai18n_file_path: '~/orai18n.jar'
-

--- a/group-vars/passwords-africa-grid.yml
+++ b/group-vars/passwords-africa-grid.yml
@@ -1,0 +1,2 @@
+---
+# Empty for now

--- a/group-vars/perun-servers.yml
+++ b/group-vars/perun-servers.yml
@@ -1,0 +1,46 @@
+---
+# Basic variables used through all roles
+
+# Login name of Perun user
+perun_login: 'perun'
+# Group name of Perun user
+perun_group: 'perun'
+# Full name of Perun user
+perun_name: 'Perun'
+# Email address of admin of Perun server
+perun_admin: 'admin@perun-test-domain.com'
+
+# Address of your Perun server
+perun_address: '192.168.56.20'
+
+# Path to repository with cloned Perun sources from GIT
+perun_folder: "/home/{{ perun_login }}/perun-sources/"
+# Path to repository with cloned Perun services from GIT
+perun_services_folder: "/home/{{ perun_login }}/perun-services/"
+
+# Database name (we recommend to don't change it)
+db_name: 'perun'
+# Database user (we recommend to don't change it)
+db_user: 'perun'
+
+# APACHE CERTIFICATE
+# Path to Apache certificate file (Default is fake snake oil, which will be created. Please change this path, if you want to use your own certificate.)
+apache_certificate_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+# Path to key for Apache certificate file (Default is key to fake snake oil, which will be created. Please change this path, if you changed certificate to your own.)
+apache_certificate_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
+# Path to directory with CA certificates
+apache_ca_certificate_path: '/etc/grid-security/certificates/'
+
+# LDAP CERTIFICATE
+# Path to CA certificate of LDAP (Default is value of apache_certificate_file. Change it, if you have separate CA certificate for LDAP.)
+ldap_ca_certificate_file: "{{ apache_certificate_file }}"
+# Path to certificate file of LDAP (Default is value of apache_certificate_file. Change it, if you have separate certificate for LDAP.)
+ldap_certificate_file: "{{ apache_certificate_file }}"
+# Path to key file of LDAP certificate (Default is value of apache_certificate_key_file.)
+ldap_certificate_key_file: "{{ apache_certificate_key_file }}"
+
+# ORACLE DB DRIVERS
+# Path to ojdbc7 file on your system with Ansible
+ojdbc7_file_path: '~/ojdbc7.jar'
+# Path to orai18n file on your system with Ansible
+orai18n_file_path: '~/orai18n.jar'

--- a/inventories/africa-grid.dev
+++ b/inventories/africa-grid.dev
@@ -1,0 +1,5 @@
+[perun-servers]
+151.97.41.47 ansible_user=ansible
+
+[africa-grid:children]
+perun-servers

--- a/site.yml
+++ b/site.yml
@@ -1,16 +1,17 @@
 ---
 # Main perun orchestration playbook
 - hosts: perun-servers
+  strategy: debug
   roles:
     # NECESSARY ROLES
     # ---------------
     # This role will create user perun and download all packages and GIT repositories you will need in installation process.
-    - perun
+    - { role: perun, become: true}
     # This role will install Apache on your server.
     - apache-perun
     # This role will install Tomcat on your server.
     - tomcat-perun
-    # This role will deploy Postgre DB on your server and prepares DB tables. 
+    # This role will deploy Postgre DB on your server and prepares DB tables.
     - postgre-perun
     # This role will copy configuration files of Perun on your server.
     - configuration-perun
@@ -25,5 +26,5 @@
     # --------------
     #- shibboleth-perun
   pre_tasks:
-    - include_vars: ./group-vars/passwords.yml
-    - include_vars: ./group-vars/all.yml
+    - include_vars: ./group-vars/africa-grid.yml
+    - include_vars: "group-vars/passwords-{{ site_name }}.yml"


### PR DESCRIPTION
hi @zwejra 

I propose here to separate the variable files on a per-site basis. I've moved the `all.yml` file to the `perun-servers.yml` file, since this applies to all hosts in the perun-server group... not exactly "all".

In order not to clobber the info in the default password and site-specific files, I've modified `site.yml` to read the site-specific passwords. This is done using a variable set in a site-specific variable file  - in this case, it's `africa-grid.yml`

