### PR TITLE
Copy perun-engine/ldapc init.d scripts from perun-utils

### DIFF
--- a/roles/engine-perun/tasks/Debian.yml
+++ b/roles/engine-perun/tasks/Debian.yml
@@ -27,23 +27,6 @@
   args:
     chdir: "{{ perun_folder }}/perun-cli"
 
-# fails on Debian 9, see https://github.com/HanXHX/ansible-nginx/issues/28
-#- name: Add user perun-engine into Apache (done by root)
-#  htpasswd:
-#    path: /etc/apache2/perun.passwd
-#    name: perun-engine
-#    password: "{{ password_perun_engine }}"
-#    state: present
-#  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
-#
-#- name: Add user perun into Apache (done by root)
-#  htpasswd:
-#    path: /etc/apache2/perun.passwd
-#    name: perun
-#    password: "{{ password_perun_admin }}"
-#    state: present
-#  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
-
 - name: Add user perun into Apache
   shell: "htpasswd -b -c /etc/apache2/perun.passwd perun {{ password_perun_admin }}"
 - name: Add user perun-engine into Apache
@@ -94,15 +77,14 @@
   args:
     chdir: "{{ perun_services_folder }}"
 
-- name: "Delete /etc/init.d/perun-engine file if exists"
-  file:
-    path: "/etc/init.d/perun-engine"
-    state: absent
-
-- name: "Copy perun-engine.debian file to /etc/init.d/perun-engine"
-  shell: cp perun-engine.debian /etc/init.d/perun-engine
-  args:
-    chdir: "{{ perun_folder }}/perun-utils/init.d-scripts/"
+- name: Copy init.d script for perun-engine
+  copy:
+    src: "{{ init_d_script[ansible_os_family].source }}"
+    dest: "{{ init_d_script[ansible_os_family].destination }}"
+    owner: root
+    group: root
+    mode: "{{ init_d_script[ansible_os_family].mode }}"
+    remote_src: yes
 
 - name: "Delete /var/run/perun directory if exists"
   file:
@@ -128,34 +110,3 @@
     name: perun-engine
     state: started
     daemon_reload: yes
-
-# installation of slave script is not needed on perun server, only on controlled machines
-#
-#- name: "Create file /etc/apt/sources.list.d/meta_repo.list"
-#  template:
-#    src: meta_repo.j2
-#    dest: /etc/apt/sources.list.d/meta_repo.list
-#    owner: "{{ perun_login }}"
-#    group: "{{ perun_group }}"
-#    mode: 0644
-#
-#- name: "Copy pgb_public_key to {{ perun_login }} user home folder"
-#  copy:
-#    src: "{{ role_path }}/files/pgb_public_key"
-#    dest: "/home/{{ perun_login }}/pgb_public_key"
-#    owner: "{{ perun_login }}"
-#    group: "{{ perun_group }}"
-#    mode: 0644
-#
-#- name: "Import pgb_public_key into credible keys"
-#  become: true
-#  apt_key:
-#    file: "/home/{{ perun_login }}/pgb_public_key"
-#    state: present
-#
-#- name: "Update repositories cache (apt-update) and install perun base slave script"
-#  become: true
-#  apt:
-#    name: perun-slave-base
-#    update_cache: yes
-#    allow_unauthenticated: yes

--- a/roles/engine-perun/vars/main.yml
+++ b/roles/engine-perun/vars/main.yml
@@ -3,3 +3,9 @@
 
 # Address of repository in metacentrum. Don't change this!
 metacentrum_repo: repo.metacentrum.cz
+
+init_d_script:
+  Debian:
+    source: "{{ perun_folder }}/perun-utils/init.d-scripts/perun-engine.debian"
+    destination: "/etc/init.d/perun-engine"
+    mode: "0755"

--- a/roles/ldap-perun/tasks/install-ldapc-Debian.yml
+++ b/roles/ldap-perun/tasks/install-ldapc-Debian.yml
@@ -19,6 +19,15 @@
     remote_src: yes
   with_dict: "{{ script_files }}"
 
+- name: Copy init.d script for perun-ldapc
+  copy:
+    src: "{{ init_d_script[ansible_os_family].source }}"
+    dest: "{{ init_d_script[ansible_os_family].destination }}"
+    owner: root
+    group: root
+    mode: "{{ init_d_script[ansible_os_family].mode }}"
+    remote_src: yes
+
 - name: Create truststore in perun-ldapc folder if you use snake-oil certificate
   java_cert:
     cert_path: "{{ apache_certificate_file }}"

--- a/roles/ldap-perun/vars/main.yml
+++ b/roles/ldap-perun/vars/main.yml
@@ -56,3 +56,9 @@ script_files:
     source: "{{ perun_folder }}/perun-ldapc-initializer/target/perun-ldapc-initializer-3.0.1-SNAPSHOT-production.jar"
     destination: "{{ perun_ldapc_folder }}/perun-ldapc-initializer-3.0.1-SNAPSHOT-production.jar"
     mode: "0644"
+
+init_d_script:
+  Debian:
+    source: "{{ perun_folder }}/perun-utils/init.d-scripts/perun-ldapc.debian"
+    destination: "/etc/init.d/perun-ldapc"
+    mode: "0755"


### PR DESCRIPTION
This commit will copy perun-ldapc init.d script from perun-utils.
It changes copying of perun-engine init.d script as well.
It also deletes unnecessary comments in perun-engine role.