### PR TITLE
set services perun-ldapc and perun-engine to start after reboot 

### DIFF
--- a/roles/engine-perun/tasks/Debian.yml
+++ b/roles/engine-perun/tasks/Debian.yml
@@ -105,8 +105,8 @@
     owner: "{{ perun_login }}"
     group: "{{ perun_group }}"
 
-- name: Start perun-engine
-  systemd:
+- name: Start perun-engine and enable it to start after reboot
+  service:
     name: perun-engine
     state: started
-    daemon_reload: yes
+    enabled: yes

--- a/roles/ldap-perun/tasks/install-ldapc-Debian.yml
+++ b/roles/ldap-perun/tasks/install-ldapc-Debian.yml
@@ -28,6 +28,7 @@
     mode: "{{ init_d_script[ansible_os_family].mode }}"
     remote_src: yes
 
+
 - name: Create truststore in perun-ldapc folder if you use snake-oil certificate
   java_cert:
     cert_path: "{{ apache_certificate_file }}"
@@ -51,7 +52,8 @@
   become: yes
   become_user: "{{ perun_login }}"
 
-- name: Start LDAPc
-  command: "{{ script_files.start.destination }}"
-  become: yes
-  become_user: "{{ perun_login }}"
+- name: Start LDAPc and enable it to start after reboot
+  service:
+    name: perun-ldapc
+    state: started
+    enabled: yes


### PR DESCRIPTION
modified tasks that start start the services to also set them as enabled after reboot