### PR TITLE
Better apache config

### DIFF
--- a/roles/apache-perun/tasks/Debian.yml
+++ b/roles/apache-perun/tasks/Debian.yml
@@ -34,6 +34,12 @@
     group: ssl-cert
     mode: 0640
 
+- name: Add user {{ perun_login }} to group ssl-cert
+  user:
+      name: "{{ perun_login }}"
+      groups: ssl-cert
+      append: yes
+
 - name: Install Apache
   package:
     name: "{{ apache_package[ansible_os_family] }}"

--- a/roles/apache-perun/tasks/Debian.yml
+++ b/roles/apache-perun/tasks/Debian.yml
@@ -23,6 +23,7 @@
 - name: Check rights on certificate
   file:
     path: "{{ apache_certificate_file }}"
+    follow: yes
     owner: root
     group: root
     mode: 0644
@@ -30,6 +31,7 @@
 - name: Check rights on certificate key
   file:
     path: "{{ apache_certificate_key_file }}"
+    follow: yes
     owner: root
     group: ssl-cert
     mode: 0640

--- a/roles/apache-perun/tasks/Debian.yml
+++ b/roles/apache-perun/tasks/Debian.yml
@@ -1,11 +1,26 @@
 # Tasks file for apache-perun
 
-# Install ssl-cert for making certificate
-- name: Install ssl-cert package
+- name: Install Apache
   package:
-    name: "{{ ssl_cert_package[ansible_os_family] }}"
+    name: "{{ apache_package[ansible_os_family] }}"
     state: present
-  when: apache_certificate_file == "/etc/perun/ssl/ssl-cert-snakeoil.pem"
+
+- name: Enable Apache modules
+  apache2_module:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ apache_modules[ansible_os_family] }}"
+  notify:
+    - "restart webserver"
+
+# ssl-cert group is created by ssl-cert package, which is dependency of apache2
+# ssl-cert group is used by packages like postgres and openldap which need access to private keys
+# perun user needs access to site key for authentication when uploading to URLs
+- name: Add user {{ perun_login }} to group ssl-cert
+  user:
+    name: "{{ perun_login }}"
+    groups: ssl-cert
+    append: yes
 
 # Fake Snake Oil if ssl_certificate_file variable is not filled
 - name: Make fake Snake Oil certificate for testing purposes
@@ -35,25 +50,6 @@
     owner: root
     group: ssl-cert
     mode: 0640
-
-- name: Add user {{ perun_login }} to group ssl-cert
-  user:
-      name: "{{ perun_login }}"
-      groups: ssl-cert
-      append: yes
-
-- name: Install Apache
-  package:
-    name: "{{ apache_package[ansible_os_family] }}"
-    state: present
-
-- name: Enable modules
-  apache2_module:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ apache_modules[ansible_os_family] }}"
-  notify:
-    - "restart webserver"
 
 - name: Remove default Apache site
   file:

--- a/roles/apache-perun/tasks/Debian_9.yml
+++ b/roles/apache-perun/tasks/Debian_9.yml
@@ -1,0 +1,88 @@
+---
+- name: Require Debian 9
+  assert:
+    that:
+      - ansible_distribution == "Debian"
+      - ansible_distribution_major_version == "9"
+    msg: "Debian 9 specific tasks"
+
+- name: fix vim mouse editing
+  lineinfile:
+    path: "/usr/share/vim/vim80/defaults.vim"
+    regexp: "set mouse=a"
+    state: absent
+
+- name: Use cronolog for error log rotation
+  lineinfile:
+    path: "/etc/apache2/apache2.conf"
+    regexp: 'ErrorLog \${APACHE_LOG_DIR}/error.log'
+    line: 'ErrorLog "|/usr/bin/cronolog /var/log/apache2/%Y/%m/%d/error.log"'
+    backrefs: yes
+  notify:
+      - "restart webserver"
+
+- name: Use cronolog for access log rotation
+  lineinfile:
+    path: "/etc/apache2/conf-enabled/other-vhosts-access-log.conf"
+    regexp: 'CustomLog \${APACHE_LOG_DIR}/other_vhosts_access.log vhost_combined'
+    line: 'CustomLog "|/usr/bin/cronolog /var/log/apache2/%Y/%m/%d/access.log" vhost_combined'
+    backrefs: yes
+  notify:
+      - "restart webserver"
+
+- name: Set ServerTokens level to Production
+  lineinfile:
+    path: "/etc/apache2/conf-enabled/security.conf"
+    regexp: 'ServerTokens OS'
+    line: 'ServerTokens Prod'
+    backrefs: yes
+  notify:
+      - "restart webserver"
+
+- name: Comment out default SSLCipherSuite
+  lineinfile:
+    path: "/etc/apache2/mods-enabled/ssl.conf"
+    regexp: 'SSLCipherSuite HIGH:!aNULL'
+    line: ' #SSLCipherSuite HIGH:!aNULL'
+  notify:
+      - "restart webserver"
+
+- name: Comment out default SSLProtocol
+  lineinfile:
+    path: "/etc/apache2/mods-enabled/ssl.conf"
+    regexp: 'SSLProtocol all -SSLv3'
+    line: ' #SSLProtocol all -SSLv3'
+  notify:
+      - "restart webserver"
+
+- name: Set up TLS correctly
+  blockinfile:
+    dest: "/etc/apache2/mods-enabled/ssl.conf"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    insertbefore: '</IfModule>'
+    block: |
+      # see https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=apache-2.4.25&openssl=1.0.2l&hsts=yes&profile=modern
+      SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
+      SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+      SSLHonorCipherOrder     on
+      SSLCompression          off
+      SSLSessionTickets       off
+
+      # OCSP Stapling, only in httpd 2.3.3 and later
+      SSLUseStapling          on
+      SSLStaplingResponderTimeout 5
+      SSLStaplingReturnResponderErrors off
+      SSLStaplingCache        shmcb:/var/run/ocsp(128000)
+
+- name: Create HTTP2 module config
+  copy:
+    dest: "/etc/apache2/mods-available/http2.conf"
+    content: |
+      Protocols h2 http/1.1
+
+- name: Enable HTTP2 module
+  apache2_module:
+    name: http2
+    state: present
+  notify:
+    - "restart webserver"

--- a/roles/apache-perun/tasks/Debian_9.yml
+++ b/roles/apache-perun/tasks/Debian_9.yml
@@ -12,6 +12,19 @@
     regexp: "set mouse=a"
     state: absent
 
+- name: fix cmd prompt
+  blockinfile:
+    dest: /root/.bashrc
+    block: |
+     # If this is an xterm set the title to user@host:dir
+     case "$TERM" in
+     xterm*|rxvt*)
+        PS1="\[\e]0;\u@$(hostname --fqdn) \w\a\]\u@$(hostname --fqdn):\w# "
+        ;;
+     *)
+        ;;
+     esac
+
 - name: Use cronolog for error log rotation
   lineinfile:
     path: "/etc/apache2/apache2.conf"

--- a/roles/apache-perun/tasks/main.yml
+++ b/roles/apache-perun/tasks/main.yml
@@ -1,2 +1,5 @@
 ---
 - include_tasks: "{{ ansible_os_family }}.yml"
+
+- include_tasks: "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "9" 

--- a/roles/apache-perun/tasks/main.yml
+++ b/roles/apache-perun/tasks/main.yml
@@ -3,3 +3,6 @@
 
 - include_tasks: "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
   when: ansible_distribution == "Debian" and ansible_distribution_major_version == "9" 
+
+- name: Restart server if needed
+  meta: flush_handlers

--- a/roles/apache-perun/vars/main.yml
+++ b/roles/apache-perun/vars/main.yml
@@ -1,7 +1,9 @@
 ---
 # vars file for apache-perun
 apache_package:
-  Debian: apache2
+  Debian:
+    - apache2
+    - cronolog
 apache_modules:
   Debian:
     - headers

--- a/roles/ldap-perun/tasks/install-ldap-Debian.yml
+++ b/roles/ldap-perun/tasks/install-ldap-Debian.yml
@@ -52,49 +52,39 @@
     olcRootPW: "{{ root_password.stdout }}"
   notify: Restart LDAP
 
-- name: Change group of openldap user to ssl-cert
+- name: Add openldap user to ssl-cert group
   user:
     name: openldap
-    groups: openldap,ssl-cert
-
-- name: Change group of certificate files/key to openldap
-  file:
-    path: "{{ item }}"
-    group: ssl-cert
-    owner: root
-  with_items:
-    - "{{ ldap_certificate_file }}"
-    - "{{ ldap_ca_certificate_file }}"
-    - "{{ ldap_certificate_key_file }}"
+    groups: ssl-cert
+    append: yes
 
 - name: Restart LDAP
   service:
     name: slapd
     state: restarted
 
-- name: Configure LDAP Core TLS Settings
-  ignore_errors: True
-  ldap_attr:
-    dn: "cn=config"
-    name: "{{ item.key }}"
-    values: "{{ item.value }}"
-    state: exact
-  with_dict:
-    olcTLSCertificateKeyFile: "{{ ldap_certificate_key_file }}"
-    olcTLSCACertificateFile: "{{ ldap_ca_certificate_file }}"
-    olcTLSCertificateFile: "{{ ldap_certificate_file }}"
-    
-- name: Configure LDAP Core TLS Settings (again, because of violation of requirements in configuration)
-  ldap_attr:
-    dn: "cn=config"
-    name: "{{ item.key }}"
-    values: "{{ item.value }}"
-    state: exact
-  with_dict:
-    olcTLSCertificateKeyFile: "{{ ldap_certificate_key_file }}"
-    olcTLSCACertificateFile: "{{ ldap_ca_certificate_file }}"
-    olcTLSCertificateFile: "{{ ldap_certificate_file }}"
-    
+- name: Create file for modifying LDAP TLS settings
+  copy:
+    dest: "/etc/ldap/ssl.ldif"
+    content: |
+      dn: cn=config
+      changetype: modify
+      replace: olcTLSCertificateFile
+      olcTLSCertificateFile: {{ ldap_certificate_file }}
+      -
+      replace: olcTLSCertificateKeyFile
+      olcTLSCertificateKeyFile: {{ ldap_certificate_key_file }}
+      -
+      replace: olcTLSCACertificateFile
+      olcTLSCACertificateFile: {{ ldap_certificate_file }}
+      -
+
+  register: ssl_ldif
+
+- name: Change TLS settings
+  command: /usr/bin/ldapmodify -Q -H ldapi:/// -Y EXTERNAL -D "{{ slapd_basedn_admin }}" -w "{{ password_ldap_config }}" -f /etc/ldap/ssl.ldif
+  when: ssl_ldif.changed
+
 - name: Enable secure port in /etc/default/slapd
   lineinfile:
    dest: /etc/default/slapd

--- a/roles/ldap-perun/tasks/install-ldap-Debian.yml
+++ b/roles/ldap-perun/tasks/install-ldap-Debian.yml
@@ -61,7 +61,7 @@
   file:
     path: "{{ item }}"
     group: ssl-cert
-    owner: "{{ perun_login }}"
+    owner: root
   with_items:
     - "{{ ldap_certificate_file }}"
     - "{{ ldap_ca_certificate_file }}"

--- a/roles/shibboleth-perun/tasks/main.yml
+++ b/roles/shibboleth-perun/tasks/main.yml
@@ -122,4 +122,7 @@
         </Attribute>
   notify:
     - "restart shibd"
+
+- name: Restart server if needed
+  meta: flush_handlers
 ...


### PR DESCRIPTION
- added user perun to group ssl-cert (and removed setting perun as owner of private key)
- fixed following symlinks when chmod for cert and key (needed for cert and key generated by certbot)
- added setup of TLS for Debian 9 (it is specific for versions of Apache and OpenSSL)
- added flushing handlers to restart servers at ends of shibboleth-perun and apache-perun
- fixed CLI prompt
- fixed LDAP TLS settings