### PR TITLE
made postgres optional and added TLS settings

### DIFF
--- a/group_vars/perun-servers.yml
+++ b/group_vars/perun-servers.yml
@@ -30,7 +30,8 @@ perun_config_dir: "/etc/perun"
 # Variables log folder for Perun
 perun_log_dir: "/var/log/perun"
 
-
+# optional installation of Postgres
+install_postgres: True
 # Database name (we recommend to don't change it)
 db_name: 'perun'
 # Database user (we recommend to don't change it)

--- a/roles/postgre-perun/tasks/Debian.yml
+++ b/roles/postgre-perun/tasks/Debian.yml
@@ -1,8 +1,5 @@
 ---
 # Task file for postgres database installation in Debian distribution
-- name:
-  include_vars:
-    file: "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
 
 - name: Install postgresql package
   become: true
@@ -30,7 +27,7 @@
   become: yes
   become_user: postgres
   blockinfile:
-    dest: "/etc/postgresql/{{ postgre_version }}/main/pg_hba.conf"
+    dest: "/etc/postgresql/{{ postgres_version[ansible_distribution+'_'+ansible_distribution_major_version] }}/main/pg_hba.conf"
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     insertafter: '# Database administrative login by Unix domain socket'
     block: |
@@ -39,9 +36,41 @@
         hostssl all   all   all          md5
   register: pg_hba
 
+- name: Set listen_addresses=* in postgresql.conf
+  lineinfile:
+    path: "/etc/postgresql/{{ postgres_version[ansible_distribution+'_'+ansible_distribution_major_version] }}/main/postgresql.conf"
+    regexp: "^#listen_addresses = \'localhost\'(.*)$"
+    line: "listen_addresses = \'*\'\\1"
+    backrefs: yes
+  register: listen_addresses
+
+- name: Set TLS cert
+  lineinfile:
+    path: "/etc/postgresql/{{ postgres_version[ansible_distribution+'_'+ansible_distribution_major_version] }}/main/postgresql.conf"
+    regexp: 'ssl_cert_file'
+    line: "ssl_cert_file = '{{apache_certificate_file}}'"
+    backrefs: yes
+  register: ssl_cert_file
+
+- name: Set TLS key
+  lineinfile:
+    path: "/etc/postgresql/{{ postgres_version[ansible_distribution+'_'+ansible_distribution_major_version] }}/main/postgresql.conf"
+    regexp: 'ssl_key_file'
+    line: "ssl_key_file = '{{apache_certificate_key_file}}'"
+    backrefs: yes
+  register: ssl_key_file
+
+- name: Set TLS CA chain
+  lineinfile:
+    path: "/etc/postgresql/{{ postgres_version[ansible_distribution+'_'+ansible_distribution_major_version] }}/main/postgresql.conf"
+    regexp: 'ssl_ca_file'
+    line: "ssl_ca_file = '{{apache_certificate_chain_file}}'"
+    backrefs: yes
+  register: ssl_ca_file
+
 - name: Set max_connections = 150
   lineinfile:
-    path: "/etc/postgresql/{{ postgre_version }}/main/postgresql.conf"
+    path: "/etc/postgresql/{{ postgres_version[ansible_distribution+'_'+ansible_distribution_major_version] }}/main/postgresql.conf"
     regexp: '^max_connections = 100(.*)$'
     line: 'max_connections = 150\1'
     backrefs: yes
@@ -49,9 +78,9 @@
 
 - name: Restart PostgreSQL
   become: true
-  when: pg_hba.changed or postgres_password.changed or max_conns.changed
+  when: pg_hba.changed or postgres_password.changed or max_conns.changed or listen_addresses.changed or ssl_cert_file.changed or ssl_key_file.changed or ssl_ca_file.changed
   service:
-    state: reloaded
+    state: restarted
     name: postgresql
 
 - name: Create user "{{ db_user }}" without superuser and createdb privileges

--- a/roles/postgre-perun/tasks/main.yml
+++ b/roles/postgre-perun/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 # tasks file for postgre-perun
 - include_tasks: "{{ ansible_os_family }}.yml"
+  when: install_postgres

--- a/roles/postgre-perun/vars/Debian_8.yml
+++ b/roles/postgre-perun/vars/Debian_8.yml
@@ -1,3 +1,0 @@
----
-# vars file for postgre-perun
-postgre_version: '9.4'

--- a/roles/postgre-perun/vars/Debian_9.yml
+++ b/roles/postgre-perun/vars/Debian_9.yml
@@ -1,3 +1,0 @@
----
-# vars file for postgre-perun
-postgre_version: '9.6'

--- a/roles/postgre-perun/vars/main.yml
+++ b/roles/postgre-perun/vars/main.yml
@@ -1,4 +1,9 @@
 ---
+
+postgres_version:
+  Debian_8: 9.4
+  Debian_9: 9.6
+
 # vars file for postgre-perun
 postgre_packages:
   Debian:


### PR DESCRIPTION
- installation of postgres is optional and enabled by new setting **install_postgres** in perun-servers.yml
- postgres server now listens on public IPs and uses TLS certificate from Apache