### PR TITLE
Fixes for idm test

### DIFF
--- a/roles/apache-perun/templates/perun-ssl.conf.j2
+++ b/roles/apache-perun/templates/perun-ssl.conf.j2
@@ -58,15 +58,6 @@ ShibCompatValidUser on
   RewriteCond  %{REQUEST_URI}  !^/
   RewriteRule  .*              -    [R=400,L]
 
-  ###################################
-  # Logging                      ####
-  ###################################
-
-  # Following handles also rewrite log
-  LogLevel warn rewrite:warn
-  ErrorLog ${APACHE_LOG_DIR}/error.log
-  CustomLog ${APACHE_LOG_DIR}/access.log combined
-
  ####################################
  ##      MAINTENANCE             ####
  ####################################

--- a/roles/apache-perun/templates/perun.conf.j2
+++ b/roles/apache-perun/templates/perun.conf.j2
@@ -14,11 +14,4 @@
         ErrorDocument 500 /maintenance/500.html
         ErrorDocument 503 /maintenance/503.html
 
-        ErrorLog ${APACHE_LOG_DIR}/error.log
-
-        # Possible values include: debug, info, notice, warn, error, crit,
-        # alert, emerg.
-        LogLevel warn
-
-        CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>

--- a/roles/perun/vars/main.yml
+++ b/roles/perun/vars/main.yml
@@ -22,3 +22,4 @@ prerequisites:
    - whois
    - apache2
    - ntpdate
+   - fail2ban

--- a/roles/perun/vars/main.yml
+++ b/roles/perun/vars/main.yml
@@ -22,4 +22,3 @@ prerequisites:
    - whois
    - apache2
    - ntpdate
-   - fail2ban

--- a/roles/security/tasks/Debian.yml
+++ b/roles/security/tasks/Debian.yml
@@ -1,0 +1,18 @@
+---
+# tool for setting firewall rules
+- name: Install iptables package
+  package:
+    name: iptables
+    state: present
+
+# tool for saving firewall rules to /etc/iptables/rules.v4 and /etc/iptables/rules.v6 to survive reboot
+- name: Install iptables-persistent package
+  package:
+    name: iptables-persistent
+    state: present
+
+# blocks IP addresses after multiple unsuccessful authentication attempts
+- name: Install fail2ban package
+  package:
+    name: fail2ban
+    state: present

--- a/roles/security/tasks/Debian.yml
+++ b/roles/security/tasks/Debian.yml
@@ -10,9 +10,49 @@
   package:
     name: iptables-persistent
     state: present
+  register: ipper
 
 # blocks IP addresses after multiple unsuccessful authentication attempts
 - name: Install fail2ban package
   package:
     name: fail2ban
     state: present
+
+# set up FW rules if package iptables-persistent was just installed
+
+- name: Stop fail2ban
+  service:
+    name: fail2ban
+    state: stopped
+  when: ipper.changed
+
+- name: Set up firewall rules
+  template:
+    backup: true
+    force: true
+    src: rules.j2
+    dest: "{{ item }}"
+  with_items:
+    - /etc/iptables/rules.v4
+    - /etc/iptables/rules.v6
+  when: ipper.changed
+
+- name: Activate IPv4 firewall rules
+  command: /sbin/iptables-restore /etc/iptables/rules.v4
+  when: ipper.changed
+
+- name: Activate IPv6 firewall rules
+  command: /sbin/ip6tables-restore /etc/iptables/rules.v6
+  when: ipper.changed
+
+- name: Start fail2ban
+  service:
+    name: fail2ban
+    state: started
+  when: ipper.changed
+
+# lock root password
+- name: Lock root password
+  user:
+    name: root
+    password: "*"

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: "{{ ansible_distribution }}.yml"
+

--- a/roles/security/templates/rules.j2
+++ b/roles/security/templates/rules.j2
@@ -1,0 +1,16 @@
+# Created by Ansible
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+-4 -A INPUT -p icmp -m comment --comment "accept all icmp" -j ACCEPT
+-6 -A INPUT -p icmpv6 -m comment --comment "accept all icmpv6" -j ACCEPT
+-A INPUT -i lo -j ACCEPT -m comment --comment "accept all on loopback"
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT -m comment --comment "accept existing connections"
+-A INPUT -p tcp -m tcp --dport 22 -j ACCEPT -m comment --comment "accept ssh"
+-A INPUT -p tcp -m tcp --dport 80 -j ACCEPT -m comment --comment "accept http"
+-A INPUT -p tcp -m tcp --dport 443 -j ACCEPT -m comment --comment "accept https"
+-A INPUT -p tcp -m tcp --dport 636 -j ACCEPT -m comment --comment "accept ldaps"
+-A INPUT -p tcp -m tcp --dport 5432 -j ACCEPT -m comment --comment "accept postgres"
+-A INPUT -j REJECT
+COMMIT

--- a/roles/work-env/tasks/Debian_9.yml
+++ b/roles/work-env/tasks/Debian_9.yml
@@ -26,3 +26,4 @@
      *)
         ;;
      esac
+     export EDITOR=vi

--- a/site.yml
+++ b/site.yml
@@ -15,10 +15,9 @@
 - hosts: perun-servers
   pre_tasks:
 
-  - name: Check that host's variables and passwords are loaded
+  - name: Check that host's variables are loaded
     assert:
       that:
-        - password_perun_admin is defined
         - perun_login is defined
         - perun_hostname is defined
         - perun_email is defined
@@ -26,8 +25,16 @@
         - apache_certificate_key_file is defined
         - ldap_certificate_file is defined
         - ldap_certificate_key_file is defined
-      msg: "Create directory host_vars/{{inventory_hostname}}/, copy there files from host_vars/perun.example.com/ and set all values in them"
+      msg: "Create directory host_vars/{{inventory_hostname}}/, copy there file host_vars/perun.example.com/vars.yml and set all values in it"
     tags: ['always']
+
+  - name: Check that host's passwords are loaded
+    assert:
+      that:
+        - password_perun_admin is defined
+        - yubikey_key is defined
+      msg: "Create directory host_vars/{{inventory_hostname}}/, copy there file host_vars/perun.example.com/passwords.yml and set all values in it"
+    tags: ['perun', 'config', 'apache', 'tomcat', 'db', 'build', 'engine', 'wui', 'ldap', 'yubikey']
 
   # Debian 7 has only Apache 2.2, which have incompatible config files with Apache 2.4
   - name: Require Debian 8,9
@@ -71,6 +78,8 @@
     - { role: wui-perun, become: true, tags: wui}
     # This role will deploy new LDAP server configuration.
     - { role: ldap-perun, become: true, tags: ldap }
+    # This role will set up security measures like firewall.
+    - { role: security, become: true, tags: security }
     # This role will deploy authentication by hardware Yubikeys.
     - { role: yubikey, become: true, tags: yubikey }
     # This role will deploy unattended upgrades of Debian OS.


### PR DESCRIPTION
- added new role "security" 
- the role installs package fail2ban which prevents DOS attacks
- the role sets up firewall opened for following protocols: ssh, http, https, ldaps and postgresql 
- removed unnecessary logging from Apache config