### PR TITLE
Do not encode query string when rewriting /*/ic/ to /*-ic/ic/

### DIFF
--- a/roles/apache-perun/templates/perun-ssl.conf.j2
+++ b/roles/apache-perun/templates/perun-ssl.conf.j2
@@ -137,8 +137,8 @@ ShibCompatValidUser on
   RewriteRule ^/(.*)-ic/ic/(.+)$ /var/www/perun-wui/$2 [L]
 
   #must be last
-  RewriteRule ^/(.*)/ic$ https://%{HTTP_HOST}/$1-ic/ic/ [L,R=301]
-  RewriteRule ^/(.*)/ic/(.*)$ https://%{HTTP_HOST}/$1-ic/ic/$2 [L,R=301]
+  RewriteRule ^/(.*)/ic$ https://%{HTTP_HOST}/$1-ic/ic/ [L,NE,R=301]
+  RewriteRule ^/(.*)/ic/(.*)$ https://%{HTTP_HOST}/$1-ic/ic/$2 [L,NE,R=301]
 
   ####################################
   ##     PROFILE                  ####


### PR DESCRIPTION
- By default apache encode query string on rewrite. It causes problems to workflow
  "Registrar -> IC -> Registrar" where last returning URL is missing params, since ? and & are
  URL encoded.