### PR TITLE
Added security and no-cache HTTP headers to default Apache config

### DIFF
--- a/roles/apache-perun/templates/perun-ssl.conf.j2
+++ b/roles/apache-perun/templates/perun-ssl.conf.j2
@@ -54,6 +54,10 @@ ShibCompatValidUser on
   Header always set X-Frame-Options DENY
   # FIX: HSTS Missing From HTTPS Server
   Header always set Strict-Transport-Security "max-age=63072000"
+  # FIX: Don't let browser to guess content type
+  Header always set X-Content-Type-Options nosniff
+  # FIX: Allow browsers to block xss (if they believe its xss).
+  Header always set X-XSS-Protection "1; mode=block"
 
   #### REWRITE
 

--- a/roles/apache-perun/templates/perun-ssl.conf.j2
+++ b/roles/apache-perun/templates/perun-ssl.conf.j2
@@ -59,6 +59,11 @@ ShibCompatValidUser on
   # FIX: Allow browsers to block xss (if they believe its xss).
   Header always set X-XSS-Protection "1; mode=block"
 
+  # Disable browser caching for our html/rpc resources
+  Header always set Cache-Control "no-cache, no-store, max-age=0, must-revalidate" "expr=%{REQUEST_URI} =~ m#^/(.*)/(gui|pwd-reset|wui|ic|registrar|publications|profile|rpc)/(.*)$#"
+  Header always set Pragma no-cache "expr=%{REQUEST_URI} =~ m#^/(.*)/(gui|pwd-reset|wui|ic|registrar|publications|profile|rpc)/(.*)$#"
+  Header always set Expires 0 "expr=%{REQUEST_URI} =~ m#^/(.*)/(gui|pwd-reset|wui|ic|registrar|publications|profile|rpc)/(.*)$#"
+
   #### REWRITE
 
   RewriteEngine On

--- a/roles/apache-perun/templates/perun-ssl.conf.j2
+++ b/roles/apache-perun/templates/perun-ssl.conf.j2
@@ -60,9 +60,9 @@ ShibCompatValidUser on
   Header always set X-XSS-Protection "1; mode=block"
 
   # Disable browser caching for our html/rpc resources
-  Header always set Cache-Control "no-cache, no-store, max-age=0, must-revalidate" "expr=%{REQUEST_URI} =~ m#^/(.*)/(gui|pwd-reset|wui|ic|registrar|publications|profile|rpc)/(.*)$#"
-  Header always set Pragma no-cache "expr=%{REQUEST_URI} =~ m#^/(.*)/(gui|pwd-reset|wui|ic|registrar|publications|profile|rpc)/(.*)$#"
-  Header always set Expires 0 "expr=%{REQUEST_URI} =~ m#^/(.*)/(gui|pwd-reset|wui|ic|registrar|publications|profile|rpc)/(.*)$#"
+  Header always set Cache-Control "no-cache, no-store, max-age=0, must-revalidate" "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|wui|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Pragma no-cache "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|wui|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
+  Header always set Expires 0 "expr=%{REQUEST_URI} =~ m#^/(.*)/((gui|pwd-reset|wui|ic|registrar|publications|profile)(/|(.*).nocache.js)|rpc/(.*))$#"
 
   #### REWRITE
 


### PR DESCRIPTION
- By default, Spring Security adds two more security headers.
  We can use them in our Apache config. One stop browsers from guessing
  content type from its source (and sometimes execute it) and
  second allow browsers to detect XSS and block it if detected.
- We want to disable browser caching of HTML and RPC resources
  so when we deploy new version, its always loaded from the server.
- We restrict adding header to our apps so other custom apps
  on the server are not affected.