### PR TITLE
Support customization of HikariCP properties through our jdbc.properties

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -37,3 +37,5 @@ orai18n_file_path: '~/orai18n.jar'
 # Federative authz
 fed_authz: 'fed'
 
+jdbc_maximumPoolSize: '150'
+jdbc_minimumIdle: '10'

--- a/roles/configuration-perun/templates/jdbc_properties.j2
+++ b/roles/configuration-perun/templates/jdbc_properties.j2
@@ -2,3 +2,5 @@ jdbc.url=jdbc:postgresql://localhost:5432/{{ db_name }}
 jdbc.username={{ db_user }}
 jdbc.password={{ password_db }}
 jdbc.driver=org.postgresql.Driver
+jdbc.maximumPoolSize={{ jdbc_maximumPoolSize }}
+jdbc.minimumIdle={{ jdbc_minimumIdle }}


### PR DESCRIPTION
- If we merge HikariCP, we might want to tweak number of allowed
  DB connections on each instance, but we will generally use
  our default (we set postgres to 150).