### PR TITLE
hold postgres and slapd from upgrades

### DIFF
--- a/roles/ldap-perun/tasks/install-ldap-Debian.yml
+++ b/roles/ldap-perun/tasks/install-ldap-Debian.yml
@@ -22,6 +22,11 @@
     state: present
   with_items: "{{prerequisites[ansible_os_family]}}"
 
+- name: Hold packages from upgrading
+  dpkg_selections:
+    name: slapd
+    selection: hold
+
 - name: Generate the root password for ldap
   shell: slappasswd -s {{ password_ldap_data_tree }}
   register: root_password

--- a/roles/postgre-perun/tasks/Debian.yml
+++ b/roles/postgre-perun/tasks/Debian.yml
@@ -8,6 +8,12 @@
     state: present
   with_items: "{{postgre_packages[ansible_os_family]}}"
 
+- name: Hold packages from upgrading
+  dpkg_selections:
+    name: "{{item}}-{{postgres_version[ansible_distribution+'_'+ansible_distribution_major_version]}}"
+    selection: hold
+  with_items: "{{postgre_packages[ansible_os_family]}}"
+
 - name: Install python-psycopg2 package
   become: true
   package:

--- a/roles/work-env/tasks/Debian_9.yml
+++ b/roles/work-env/tasks/Debian_9.yml
@@ -1,11 +1,12 @@
 ---
 # Sets working environment on Debian to sensible state
 
-- name: Install vim and htop
+- name: Install vim, htop and locate
   apt:
     name:
       - vim
       - htop
+      - locate
     state: latest
 
 - name: fix vim mouse editing


### PR DESCRIPTION
Perun does not survice restart of PostgreSQL, so upgrades of its packages are disabled by marking the packages as "hold". The same applies for slapd.