### PR TITLE
Deploy also CLI tools to /opt/perun-cli/bin/

### DIFF
--- a/roles/engine-perun/tasks/Debian.yml
+++ b/roles/engine-perun/tasks/Debian.yml
@@ -27,6 +27,20 @@
   args:
     chdir: "{{ perun_folder }}/perun-cli"
 
+- name: Create /opt/perun-cli/bin directory
+  file:
+    path: "/opt/perun-cli/bin"
+    state: directory
+    owner: "{{ perun_login }}"
+    group: "{{ perun_group }}"
+
+- name: Copy CLI scripts to /opt/perun-cli/bin/ directory
+  become: yes
+  become_user: "{{ perun_login }}"
+  command: rsync --exclude "Perun" ./* /opt/perun-cli/bin/
+  args:
+    chdir: "{{ perun_folder }}/perun-cli"
+
 - name: Add user perun into Apache
   shell: "htpasswd -b -c /etc/apache2/perun.passwd perun {{ password_perun_admin }}"
 - name: Add user perun-engine into Apache


### PR DESCRIPTION
- We already deployed lib/ for engine purpose, but its handy
  to have also matching CLI tools deployed in bin/ so we can
  configure new instance more easily.