### PR TITLE
Include current folder to perl libs for engine

### DIFF
--- a/roles/configuration-perun/templates/perun_engine.j2
+++ b/roles/configuration-perun/templates/perun_engine.j2
@@ -3,6 +3,8 @@
 export PERUN_USER=perun-engine/{{ password_perun_engine }}
 export PERUN_URL=https://{{ perun_hostname }}/ba/rpc/
 export PERL5LIB=/opt/perun-cli/lib/
+# On Debian 9 / Perl 5.24.1 doesn't automatically include current folder to perl libs, so we must include it manually
+export PERL5LIB=$PERL5LIB":."
 # remove on production or set to 1
 export PERL_LWP_SSL_VERIFY_HOSTNAME=0
 


### PR DESCRIPTION
- Debian 9 / Perl 5.24.1 doesn't include current folder to perl
  libs, so we must define it explicitly so gen/send scripts
  see necessary libraries.