### PR TITLE
New way of Perun-WUI deployment

### DIFF
--- a/roles/configuration-perun/templates/perun_web_gui_properties.j2
+++ b/roles/configuration-perun/templates/perun_web_gui_properties.j2
@@ -76,6 +76,8 @@ wayf.spLoginUrl=https://{{perun_hostname}}/Consolidator.sso/Login
 ### User Profile ###
 
 # defines urn of user attributes that should be displayed on personal page
+# you can force showing custom description with each attribute like: urn:perun:user:attribute-def:core:displayName[singleDescription]
+# or translated like: urn:perun:user:attribute-def:core:displayName[English|NativeDescription]
 profile.personal.showAttributes=urn:perun:user:attribute-def:core:displayName, urn:perun:user:attribute-def:def:organization, urn:perun:user:attribute-def:def:preferredMail
 
 ### {pages to hide: 'identities', 'organizations', 'groups', 'resources', 'privacy'}

--- a/roles/wui-perun/tasks/main.yml
+++ b/roles/wui-perun/tasks/main.yml
@@ -5,19 +5,21 @@
   become: yes
   become_user: "{{ perun_login }}"
   git:
-    repo: https://github.com/zlamalp/perun-wui.git
+    repo: https://github.com/CESNET/perun-wui.git
     dest: "{{ perun_wui_folder }}"
     version: master
     update: yes
+  register: git_updated
 
 - name: "Build Perun's Web User Interface. WARNING: THIS CAN TAKE SEVERAL MINUTES!"
   become: yes
   become_user: "{{ perun_login }}"
-  shell: "mvn -T {{ maven_parallel_build_threads | default(1) }} install -DskipTests -Dproduction"
+  shell: "mvn clean install -DskipTests"
   args:
     chdir: "{{ perun_wui_folder }}"
   async: 1200
   poll: 5
+  when: git_updated.changed
 
 - name: "Delete /var/www/perun-wui directory if exists"
   file:
@@ -31,27 +33,51 @@
     owner: "{{ perun_login }}"
     group: "{{ perun_group }}"
 
-- name: Deploy WUI
+- name: Deploy WUI - Admin
   become: yes
   become_user: "{{ perun_login }}"
-  command: cp -r "{{ item }}" /var/www/perun-wui/
-  with_items:
-    - "{{ perun_wui_folder }}/perun-wui-admin/target/perun-wui-admin-3.0.1-SNAPSHOT-production/PerunAdmin"
-    - "{{ perun_wui_folder }}/perun-wui-admin/target/perun-wui-admin-3.0.1-SNAPSHOT-production/PerunAdmin.html"
-    - "{{ perun_wui_folder }}/perun-wui-consolidator/target/perun-wui-consolidator-3.0.1-SNAPSHOT-production/PerunConsolidator"
-    - "{{ perun_wui_folder }}/perun-wui-consolidator/target/perun-wui-consolidator-3.0.1-SNAPSHOT-production/PerunConsolidatorElixir.html"
-    - "{{ perun_wui_folder }}/perun-wui-consolidator/target/perun-wui-consolidator-3.0.1-SNAPSHOT-production/PerunConsolidator.html"
-    - "{{ perun_wui_folder }}/perun-wui-consolidator/target/perun-wui-consolidator-3.0.1-SNAPSHOT-production/PerunConsolidatorMU.html"
-    - "{{ perun_wui_folder }}/perun-wui-profile/target/perun-wui-profile-3.0.1-SNAPSHOT-production/PerunProfile"
-    - "{{ perun_wui_folder }}/perun-wui-profile/target/perun-wui-profile-3.0.1-SNAPSHOT-production/PerunProfileElixir.html"
-    - "{{ perun_wui_folder }}/perun-wui-profile/target/perun-wui-profile-3.0.1-SNAPSHOT-production/PerunProfile.html"
-    - "{{ perun_wui_folder }}/perun-wui-pwdreset/target/perun-wui-pwdreset-3.0.1-SNAPSHOT-production/PerunPwdReset"
-    - "{{ perun_wui_folder }}/perun-wui-pwdreset/target/perun-wui-pwdreset-3.0.1-SNAPSHOT-production/PerunPwdResetElixir.html"
-    - "{{ perun_wui_folder }}/perun-wui-pwdreset/target/perun-wui-pwdreset-3.0.1-SNAPSHOT-production/PerunPwdReset.html"
-    - "{{ perun_wui_folder }}/perun-wui-pwdreset/target/perun-wui-pwdreset-3.0.1-SNAPSHOT-production/PerunPwdResetMU.html"
-    - "{{ perun_wui_folder }}/perun-wui-registrar/target/perun-wui-registrar-3.0.1-SNAPSHOT-production/PerunRegistrar"
-    - "{{ perun_wui_folder }}/perun-wui-registrar/target/perun-wui-registrar-3.0.1-SNAPSHOT-production/PerunRegistrarBBMRI.html"
-    - "{{ perun_wui_folder }}/perun-wui-registrar/target/perun-wui-registrar-3.0.1-SNAPSHOT-production/PerunRegistrarElixir.html"
-    - "{{ perun_wui_folder }}/perun-wui-registrar/target/perun-wui-registrar-3.0.1-SNAPSHOT-production/PerunRegistrar.html"
-    - "{{ perun_wui_folder }}/perun-wui-registrar/target/perun-wui-registrar-3.0.1-SNAPSHOT-production/PerunRegistrarMU.html"
-    - "{{ perun_wui_folder }}/perun-wui-registrar/target/perun-wui-registrar-3.0.1-SNAPSHOT-production/PerunRegistrarVSUP.html"
+  command: rsync --exclude "WEB-INF" --exclude "META-INF" -avz {{ perun_wui_admin }} /var/www/perun-wui/
+  args:
+    creates: "/var/www/perun-wui/PerunAdmin"
+
+- name: Deploy WUI - Profile
+  become: yes
+  become_user: "{{ perun_login }}"
+  command: rsync --exclude "WEB-INF" --exclude "META-INF" -avz {{ perun_wui_profile }} /var/www/perun-wui/
+  args:
+    creates: "/var/www/perun-wui/PerunProfile"
+
+- name: Deploy WUI - Password Reset
+  become: yes
+  become_user: "{{ perun_login }}"
+  command: rsync --exclude "WEB-INF" --exclude "META-INF" -avz {{ perun_wui_pwdreset }} /var/www/perun-wui/
+  args:
+    creates: "/var/www/perun-wui/PerunPwdReset"
+
+- name: Deploy WUI - Registrar
+  become: yes
+  become_user: "{{ perun_login }}"
+  command: rsync --exclude "WEB-INF" --exclude "META-INF" -avz {{ perun_wui_registrar }} /var/www/perun-wui/
+  args:
+    creates: "/var/www/perun-wui/PerunRegistrar"
+
+- name: Deploy WUI - Set Affiliation
+  become: yes
+  become_user: "{{ perun_login }}"
+  command: rsync --exclude "WEB-INF" --exclude "META-INF" -avz {{ perun_wui_setaffiliation }} /var/www/perun-wui/
+  args:
+    creates: "/var/www/perun-wui/PerunSetAffiliation"
+
+- name: Deploy WUI - Identity Consolidator
+  become: yes
+  become_user: "{{ perun_login }}"
+  command: rsync --exclude "WEB-INF" --exclude "META-INF" -avz {{ perun_wui_consolidator }} /var/www/perun-wui/
+  args:
+    creates: "/var/www/perun-wui/PerunConsolidator"
+
+- name: Deploy WUI - Cabinet
+  become: yes
+  become_user: "{{ perun_login }}"
+  command: rsync --exclude "WEB-INF" --exclude "META-INF" -avz {{ perun_wui_cabinet }} /var/www/perun-wui/
+  args:
+    creates: "/var/www/perun-wui/PerunCabinet"

--- a/roles/wui-perun/vars/main.yml
+++ b/roles/wui-perun/vars/main.yml
@@ -1,3 +1,10 @@
 ---
 # Vars file for wui-perun
 
+perun_wui_admin: "{{ perun_wui_folder }}/perun-wui-admin/target/perun-wui-admin/"
+perun_wui_profile: "{{ perun_wui_folder }}/perun-wui-profile/target/perun-wui-profile/"
+perun_wui_registrar: "{{ perun_wui_folder }}/perun-wui-registrar/target/perun-wui-registrar/"
+perun_wui_pwdreset: "{{ perun_wui_folder }}/perun-wui-pwdreset/target/perun-wui-pwdreset/"
+perun_wui_cabinet: "{{ perun_wui_folder }}/perun-wui-cabinet/target/perun-wui-cabinet/"
+perun_wui_consolidator: "{{ perun_wui_folder }}/perun-wui-consolidator/target/perun-wui-consolidator/"
+perun_wui_setaffiliation: "{{ perun_wui_folder }}/perun-wui-setAffiliation/target/perun-wui-setAffiliation/"


### PR DESCRIPTION
- We will use central CESNET repository.
- We use version-less folders (since we started versioning WUI).
- Each webapp is now own ansible idempotent task.
- Updated comment in perun-web-gui.properties