### PR TITLE
added option for SASL login namespace

### DIFF
--- a/host_vars/perun.example.com/vars.yml
+++ b/host_vars/perun.example.com/vars.yml
@@ -18,8 +18,8 @@ apache_certificate_key_file: '/etc/perun/ssl/ssl-cert-snakeoil.key'
 # Path to file with chain of CA  certificates. (SSLCertificateChainFile).
 apache_certificate_chain_file: '/etc/perun/ssl/ssl-cert-snakeoil.pem'
 
-# Path to directory with CA certificates. If you leave it with default value, IGTF certificates will be installed.
-apache_ca_certificate_path: '/etc/grid-security/certificates/'
+# Path to directory with CA certificates. If you uncomment it and leave it with default value, IGTF certificates will be installed.
+# apache_ca_certificate_path: '/etc/grid-security/certificates/'
 
 # LDAP CERTIFICATE
 # Path to LDAP certificate file (olcTLSCertificateFile).

--- a/host_vars/perun.example.com/vars.yml
+++ b/host_vars/perun.example.com/vars.yml
@@ -33,6 +33,7 @@ ldap_ca_certificate_file: "{{apache_certificate_chain_file}}"
 slapd_domain: 'example.com'
 slapd_basedn: '{{ "dc=" + slapd_domain.split(".") | join(",dc=") }}'
 slapd_basedn_admin: '{{ "cn=admin," + slapd_basedn }}'
+slapd_password_sasl_login_namespace: 'EXAMPLE'
 
 # Comma separated list of entityIDs of proxy IdPs which is infront of Perun.
 # So Perun can work with them differently.

--- a/roles/apache-perun/tasks/Debian.yml
+++ b/roles/apache-perun/tasks/Debian.yml
@@ -143,21 +143,21 @@
     id: 3CDBBC71
     url: "https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3"
     state: present
-  when: apache_ca_certificate_path == "/etc/grid-security/certificates/"
+  when: apache_ca_certificate_path is defined and apache_ca_certificate_path == "/etc/grid-security/certificates/"
 
 - name: Add EGI IGTF repository
   apt_repository:
     repo: 'deb http://repository.egi.eu/sw/production/cas/1/current egi-igtf core'
     filename: 'igtf'
     state: present
-  when: apache_ca_certificate_path == "/etc/grid-security/certificates/"
+  when: apache_ca_certificate_path is defined and apache_ca_certificate_path == "/etc/grid-security/certificates/"
 
 - name: Install latest IGTF certificates
   apt:
     name: ca-policy-egi-core
     state: latest
     update_cache: yes
-  when: apache_ca_certificate_path == "/etc/grid-security/certificates/"
+  when: apache_ca_certificate_path is defined and apache_ca_certificate_path == "/etc/grid-security/certificates/"
   notify:
     - "restart webserver"
 
@@ -166,21 +166,21 @@
     name: fetch-crl
     state: latest
     update_cache: yes
-  when: apache_ca_certificate_path == "/etc/grid-security/certificates/"
+  when: apache_ca_certificate_path is defined and apache_ca_certificate_path == "/etc/grid-security/certificates/"
 
 - name: Disable error emails from fetch-crl
   lineinfile:
     dest: /etc/fetch-crl.conf
     insertafter: EOF
     line: "noerrors"
-  when: apache_ca_certificate_path == "/etc/grid-security/certificates/"
+  when: apache_ca_certificate_path is defined and apache_ca_certificate_path == "/etc/grid-security/certificates/"
 
 # Rehash certificates for user identification
 - name: Use c_rehash to your certificates
   command: c_rehash .
   args:
     chdir: "{{ apache_ca_certificate_path }}"
-  when: apache_ca_certificate_path != "/etc/grid-security/certificates/"
+  when: apache_ca_certificate_path is defined and apache_ca_certificate_path != "/etc/grid-security/certificates/"
   notify:
     - "restart webserver"
 

--- a/roles/ldap-perun/templates/perun_ldapc_properties.j2
+++ b/roles/ldap-perun/templates/perun_ldapc_properties.j2
@@ -3,4 +3,5 @@ ldap.userDn={{ slapd_basedn_admin }}
 ldap.base={{ slapd_basedn }}
 ldap.password={{ password_ldap_data_tree }}
 ldap.consumerName=ldapcConsumer
-ldap.loginNamespace=EINFRA
+ldap.loginNamespace={{ slapd_password_sasl_login_namespace }}
+# password for cn=admin,cn=config: {{ password_ldap_config }}


### PR DESCRIPTION
- added option slapd_password_sasl_login_namespace for SASL login Kerberos namespace
- also made IGTF certificates optional, when apache_ca_certificate_path is not defined, the installation is skipped