### PR TITLE
Added new perun-registrar properties

### DIFF
--- a/roles/configuration-perun/templates/perun_registrar_lib.j2
+++ b/roles/configuration-perun/templates/perun_registrar_lib.j2
@@ -10,3 +10,12 @@ backupTo={{ perun_email }}
 
 # Federative authz
 fedAuthz={{ fed_authz }}
+
+# Java MAIL properties for sending notifications
+mail.smtp.host=localhost
+mail.smtp.port=25
+mail.smtp.auth=false
+mail.smtp.starttls.enable=false
+mail.debug=false
+registrar.smtp.user=
+registrar.smtp.pass=


### PR DESCRIPTION
- We now allow setting custom SMTP server config for registrar.
  Values presented in a file are default (sending to localhost:25),
  since by default installed sendmail handles mails for us.