### PR TITLE
Use shared SMTP settings in perun.properties

### DIFF
--- a/roles/configuration-perun/templates/perun_properties.j2
+++ b/roles/configuration-perun/templates/perun_properties.j2
@@ -97,3 +97,12 @@ perun.proxyIdPs= {{ proxy_idps }}
 # perun.attributesForUpdate.idp=
 # perun.attributesForUpdate.x509=
 #
+
+# Java MAIL properties for sending notifications
+mail.smtp.host=localhost
+mail.smtp.port=25
+mail.smtp.auth=false
+mail.smtp.starttls.enable=false
+mail.debug=false
+perun.smtp.user=
+perun.smtp.pass=

--- a/roles/configuration-perun/templates/perun_registrar_lib.j2
+++ b/roles/configuration-perun/templates/perun_registrar_lib.j2
@@ -10,12 +10,3 @@ backupTo={{ perun_email }}
 
 # Federative authz
 fedAuthz={{ fed_authz }}
-
-# Java MAIL properties for sending notifications
-mail.smtp.host=localhost
-mail.smtp.port=25
-mail.smtp.auth=false
-mail.smtp.starttls.enable=false
-mail.debug=false
-registrar.smtp.user=
-registrar.smtp.pass=


### PR DESCRIPTION
- SMTP configuration was moved from perun-registrar-lib.properties
  to perun.properties.
- registrar.smtp.user/pass renamed to perun.smtp.user/pass
- This change is related to #2182 and will be part of 3.6.0,
  maybe even some bugfix release in 3.5 branch.