### PR TITLE
Logging file perun-engine.log was missing in logback config

### DIFF
--- a/roles/configuration-perun/templates/logback_engine_xml.j2
+++ b/roles/configuration-perun/templates/logback_engine_xml.j2
@@ -10,6 +10,7 @@
 
 
 	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-engine">
+		<file>${LOGDIR}perun-engine.log</file>
 		<!-- see https://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy -->
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
 			<fileNamePattern>${LOGDIR}perun-engine.log.%d.%i</fileNamePattern>
@@ -25,10 +26,10 @@
 	<root level="info">
 		<appender-ref ref="perun-engine" />
 	</root>
-	
+
 	<logger name="cz.metacentrum.perun.engine" level="debug">
 	</logger>
-	
+
 	<!-- keep Spring quiet -->
 	<logger name="org.springframework" level="warn"/>
 


### PR DESCRIPTION
- Unlike any other log file we created perun-engine log files
  explicitly with day and count number omitting presence of the
  base file perun-engine.log.
- This is now fixed. Current log file is always perun-engine.log
  and rotated files are perun-engine.log.[YYYY-MM-DD].[counter].