### PR TITLE
Updated configuration files to support Perun 3.5.2

### DIFF
--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -39,5 +39,10 @@ orai18n_file_path: '~/orai18n.jar'
 # Federative authz
 fed_authz: 'fed'
 
+# JDBC HikariCP configuration - see property explanation in jdbc_properties.j2 (/etc/perun/jdbc.properties)
 jdbc_maximumPoolSize: '150'
 jdbc_minimumIdle: '10'
+jdbc_connectionTimeout: '300000'
+jdbc_maxLifetime: '1800000'
+jdbc_idleTimeout: '600000'
+jdbc_leakDetectionThreshold: '30000'

--- a/roles/configuration-perun/templates/jdbc_properties.j2
+++ b/roles/configuration-perun/templates/jdbc_properties.j2
@@ -2,5 +2,30 @@ jdbc.url=jdbc:postgresql://localhost:5432/{{ db_name }}
 jdbc.username={{ db_user }}
 jdbc.password={{ password_db }}
 jdbc.driver=org.postgresql.Driver
+
+# HikariCP suggest to match number of connections with number of CPUs available.
+# Using same values -> fix-sized-pool better handles spike demands.
+# Max. should be below DB limit (which si by default 150 for Perun).
+# Ideal seems to be like 25 / 10
 jdbc.maximumPoolSize={{ jdbc_maximumPoolSize }}
 jdbc.minimumIdle={{ jdbc_minimumIdle }}
+
+# How long Perun waits for connection from the pool before exception is thrown. Value is in millis.
+# Our default is 5 minutes / Hikari default is 30s
+jdbc.connectionTimeout={{ jdbc_connectionTimeout }}
+
+# How long we keep one connection in the pool before eviction. Value is in millis.
+# Currently used connection are evicted only after returning to the pool if they exceeded the limit.
+# Must be below any DB or infrastructure limit.
+# Hikari default is 30 minutes.
+jdbc.maxLifetime={{ jdbc_maxLifetime }}
+
+# How long we keep idle connections in the pool before eviction.
+# Must be several seconds below maxLifetime.
+# Hikari default is 10 minutes.
+jdbc.idleTimeout={{ jdbc_idleTimeout }}
+
+# Log connections which are stuck in the process of closing and before their returning to the pool for specified time.
+# Value is in millis.
+# Hikari default is 0 (disabled), our default is 30 seconds
+jdbc.leakDetectionThreshold={{ jdbc_leakDetectionThreshold }}

--- a/roles/configuration-perun/templates/perun_notification_properties.j2
+++ b/roles/configuration-perun/templates/perun_notification_properties.j2
@@ -1,12 +1,6 @@
-notif.mailSmtpAuth=false
-notif.username=
-notif.password=
-notif.smtpHost=localhost
-notif.port=8086
 notif.emailFrom=perun@localhost
 notif.fromText=Test message
 notif.sendMessages=true
-notif.starttls=false
 notif.jabber.jabberServer=jabber.org
 notif.jabber.port=5222
 notif.jabber.serviceName=jabber.org

--- a/roles/configuration-perun/templates/perun_properties.j2
+++ b/roles/configuration-perun/templates/perun_properties.j2
@@ -100,3 +100,12 @@ perun.proxyIdPs= {{ proxy_idps }}
 # perun.attributesForUpdate.idp=
 # perun.attributesForUpdate.x509=
 #
+
+# Shared SMTP configuration, following values are default, uncomment to change them.
+#mail.smtp.host=localhost
+#mail.smtp.port=25
+#mail.smtp.auth=false
+#mail.smtp.starttls.enable=false
+#mail.debug=false
+#perun.smtp.user=
+#perun.smtp.pass=

--- a/roles/configuration-perun/templates/perun_registrar_lib.j2
+++ b/roles/configuration-perun/templates/perun_registrar_lib.j2
@@ -10,12 +10,3 @@ backupTo={{ perun_email }}
 
 # Federative authz
 fedAuthz={{ fed_authz }}
-
-# Java MAIL properties for sending notifications
-mail.smtp.host=localhost
-mail.smtp.port=25
-mail.smtp.auth=false
-mail.smtp.starttls.enable=false
-mail.debug=false
-registrar.smtp.user=
-registrar.smtp.pass=


### PR DESCRIPTION
- Added optional SMTP configuration to perun.properties
- Removed now unused SMTP configuration from perun-registrar.properties
  and perun-notification.properties
- Updated jdbc.properties with new options for HikariCP. Default values
  are stored in vars.yml.