### PR TITLE
Added new optional param to perun.properties

### DIFF
--- a/roles/configuration-perun/templates/perun_properties.j2
+++ b/roles/configuration-perun/templates/perun_properties.j2
@@ -109,3 +109,6 @@ perun.proxyIdPs= {{ proxy_idps }}
 #mail.debug=false
 #perun.smtp.user=
 #perun.smtp.pass=
+
+# For which login-namespaces will perun auto-create necessary attributes (comma separated list)
+perun.autocreatedNamespaces=


### PR DESCRIPTION
- We now allow specifying login-namespaces for which we want to
  auto-create necessary attributes in Perun.
- Compatible for 3.5.4+.