### PR TITLE
Added param perun.rt.sendToMail to perun.properties

### DIFF
--- a/roles/configuration-perun/templates/perun_properties.j2
+++ b/roles/configuration-perun/templates/perun_properties.j2
@@ -41,6 +41,9 @@ perun.rt.serviceuser.username =
 # Perun service user for RT tickets
 perun.rt.serviceuser.password =
 
+# all RT tickets will be sent to this address as mails (we won't call RT API)
+perun.rt.sendToMail =
+
 # Program which ensures password changes
 perun.passwordManager.program = /bin/true
 


### PR DESCRIPTION
- Filling param with mail will cause Perun to send all RT messages
  to such mail address instead of contacting RT API.
- Compatible for 3.5.5+.