### PR TITLE
Support new LDAPc installation

### DIFF
--- a/roles/ldap-perun/tasks/install-ldapc-Debian.yml
+++ b/roles/ldap-perun/tasks/install-ldapc-Debian.yml
@@ -36,6 +36,24 @@
     mode: 0640
     force: no
 
+- name: Create file "{{ perun_ldapc_attributes_xml_file }}"
+  template:
+    src: "{{ perun_ldapc_attributes_xml_template }}"
+    dest: "{{ perun_ldapc_attributes_xml_file }}"
+    owner: "{{ config_files_owner }}"
+    group: "{{ perun_group }}"
+    mode: 0640
+    force: no
+
+- name: Create file "{{ perun_ldapc_file }}"
+  template:
+    src: "{{ perun_ldapc_template }}"
+    dest: "{{ perun_ldapc_file }}"
+    owner: "{{ config_files_owner }}"
+    group: "{{ perun_group }}"
+    mode: 0640
+    force: no
+
 - name: Create perun-ldapc folder in perun's home repository
   file:
     path: "{{ perun_ldapc_folder }}"
@@ -86,12 +104,6 @@
     dest: /etc/perun/perun-ldapc
     content: 'JAVA_OPTS=" -Djavax.net.ssl.trustStore={{ perun_ldapc_folder }}/truststore -Djavax.net.ssl.trustStorePassword={{ password_ldap_snakeoil_truststore }} -Djavax.net.ssl.trustStoreType=JKS"'
   when: apache_certificate_file == "/etc/perun/ssl/ssl-cert-snakeoil.pem"
-
-- name: Run initialize script
-  ignore_errors: True
-  command: "{{ script_files.initialize.destination }}"
-  become: yes
-  become_user: "{{ perun_login }}"
 
 - name: Start LDAPc and enable it to start after reboot
   service:

--- a/roles/ldap-perun/templates/perun_ldapc.j2
+++ b/roles/ldap-perun/templates/perun_ldapc.j2
@@ -1,0 +1,4 @@
+# Set if you wish to start the LDAPc with specific last processed ID or set "--sync" to enforce full PERUN-LDAP sync on start.
+# Comment it out, if you wish to start LDAPc just from the point it stopped.
+#
+LAST_PROCESSED_ID="--sync"

--- a/roles/ldap-perun/templates/perun_ldapc_attributes_xml.j2
+++ b/roles/ldap-perun/templates/perun_ldapc_attributes_xml.j2
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:ldap="http://www.springframework.org/schema/ldap"
+       xsi:schemaLocation="
+                                    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                                    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                                    http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd
+                                    http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
+
+</beans>

--- a/roles/ldap-perun/vars/main.yml
+++ b/roles/ldap-perun/vars/main.yml
@@ -25,29 +25,9 @@ ldapc_config_file: "{{ perun_config_dir }}/logback-ldapc.xml"
 ldapc_utils: "{{ perun_folder }}/perun-utils/ldapc-scripts"
 
 script_files:
-  initialize:
-    source: "{{ ldapc_utils }}/initialize-ldap.sh"
-    destination: "{{ perun_ldapc_folder }}/initialize-ldap.sh"
-    mode: "0744"
-  ldifDiff:
-    source: "{{ ldapc_utils }}/ldifdiff.pl"
-    destination: "{{ perun_ldapc_folder }}/ldifdiff.pl"
-    mode: "0744"
-  ldifDiffSort:
-    source: "{{ ldapc_utils }}/ldifdiff-sort.pl"
-    destination: "{{ perun_ldapc_folder }}/ldifdiff-sort.pl"
-    mode: "0744"
-  ldifSort:
-    source: "{{ ldapc_utils }}/ldifsort.pl"
-    destination: "{{ perun_ldapc_folder }}/ldifsort.pl"
-    mode: "0744"
   ldapcJar:
     source: "{{ perun_folder }}/perun-ldapc/target/perun-ldapc.jar"
     destination: "{{ perun_ldapc_folder }}/perun-ldapc.jar"
-    mode: "0644"
-  ldapcInitializerJar:
-    source: "{{ perun_folder }}/perun-ldapc-initializer/target/perun-ldapc-initializer.jar"
-    destination: "{{ perun_ldapc_folder }}/perun-ldapc-initializer.jar"
     mode: "0644"
 
 init_d_script:
@@ -68,3 +48,10 @@ logback_ldapc_xml_file: "{{ perun_config_dir }}/logback-ldapc.xml"
 perun_rpc_lib_properties_template: perun_rpc_lib_properties.j2
 perun_rpc_lib_properties_file: "{{ perun_config_dir }}/perun-rpc-lib.properties"
 
+# Template file and destination in remote system for perun-ldapc-attributes.xml
+perun_ldapc_attributes_xml_template: perun_ldapc_attributes_xml.j2
+perun_ldapc_attributes_xml_file: "{{ perun_config_dir }}/perun-ldapc-attributes.xml"
+
+# Template file and destination in remote system for perun-ldapc
+perun_ldapc_template: perun_ldapc.j2
+perun_ldapc_file: "{{ perun_config_dir }}/perun-ldapc"


### PR DESCRIPTION
- This can be merged only after release of Perun 3.8.0 !
- Script files for older LDAPc are now unused and won't be deployed.
- Old LDAPc jars won't be deployed, new with the same name will be used.
- We no longer perform explicit sync after install, it is done
  by default by new LDAPc on service start.
- Added required config files with default values (forcing sync on
  LDAPc startup).