### PR TITLE
Added voPersonExternalAffiliation

### DIFF
--- a/roles/shibboleth-perun/tasks/Debian.yml
+++ b/roles/shibboleth-perun/tasks/Debian.yml
@@ -119,6 +119,12 @@
       <!-- OrcID -->
       <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.16" id="eduPersonOrcid"/>
 
+      <!-- External affiliations provided by the Proxy (with scope different from the proxy)
+          If Perun is configured with proxy, then original IdP affiliations are sent in
+          affiliation attribute. This is filled only when original IdP is also a Proxy.
+          For us it was previously known as forwardedScopedAffiliation -->
+      <Attribute name="urn:oid:1.3.6.1.4.1.34998.3.3.1.11" id="voPersonExternalAffiliation"/>
+
   notify:
     - "restart shibd"
 


### PR DESCRIPTION
- It is generic attribute which contains external affiliations of user
  (with scope not related to the used IdP). This is usually provided
  by proxy IdP to the services.
  If proxy is before Perun, then is pushes source affiliation
  (voPersonExternalAffiliation) in standard affiliation attribute, so it
  is stored within proper attribute.
  So this attribute is present only when original IdP used by user
  is a proxy too. Then "affiliation" contains "affiliate@proxy" and
  "voPersonExternalAffiliation" contains other affiliations.