### PR TITLE
perun_roles template change

### DIFF
--- a/roles/configuration-perun/templates/perun_roles_yml.j2
+++ b/roles/configuration-perun/templates/perun_roles_yml.j2
@@ -1,22 +1,31 @@
 ---
-# A list of Perun roles that are loaded to the database
-- PERUNADMIN
-- PERUNOBSERVER
-- VOADMIN
-- GROUPADMIN
-- SELF
-- FACILITYADMIN
-- RESOURCEADMIN
-- RESOURCESELFSERVICE
-- REGISTRAR
-- ENGINE
-- RPC
-- NOTIFICATIONS
-- SERVICEUSER
-- SPONSOR
-- VOOBSERVER
-- TOPGROUPCREATOR
-- SECURITYADMIN
-- CABINETADMIN
-- UNKNOWN
+# A list of Perun roles that are loaded to the database.
+perun_roles:
+  - PERUNADMIN
+  - PERUNOBSERVER
+  - VOADMIN
+  - GROUPADMIN
+  - SELF
+  - FACILITYADMIN
+  - RESOURCEADMIN
+  - RESOURCESELFSERVICE
+  - REGISTRAR
+  - ENGINE
+  - RPC
+  - NOTIFICATIONS
+  - SERVICEUSER
+  - SPONSOR
+  - VOOBSERVER
+  - TOPGROUPCREATOR
+  - SECURITYADMIN
+  - CABINETADMIN
+  - UNKNOWN
+
+#A list of Perun policies that are loaded to the PerunPoliciesContainer.
+perun_policies:
+
+  default_policy:
+    policy_roles:
+      - PERUNADMIN:
+    include_policies: []
 ...


### PR DESCRIPTION
- Perun roles are now listed under the key perun_roles.
- Template now also contains key perun_policies with default policy which
  will be used later.