### PR TITLE
Removed "create initial user" task form postgres-perun

### DIFF
--- a/roles/postgres-perun/tasks/Debian.yml
+++ b/roles/postgres-perun/tasks/Debian.yml
@@ -231,12 +231,6 @@
   command: psql -d "{{ db_name }}" -f "{{ postgres_conf_file_path }}"
   when: table_users.rc == 1
 
-- name: Create initial users in database
-  become: yes
-  become_user: "{{ db_user }}"
-  command: psql -d "{{ db_name }}" -c "insert into perun.ext_sources (id,name,type) values (nextval('ext_sources_id_seq'),'INTERNAL','cz.metacentrum.perun.core.impl.ExtSourceInternal');insert into perun.users (id, first_name, last_name) values (nextval('users_id_seq'),'{{ init_user_first_name }}','{{ init_user_last_name }}');insert into perun.user_ext_sources (id, user_id, login_ext, ext_sources_id, loa) values (nextval('user_ext_sources_id_seq'), currval('users_id_seq'), 'perun', currval('ext_sources_id_seq'), 0);insert into perun.auditer_consumers (id, name, last_processed_id) values (nextval('auditer_consumers_id_seq'), '127.0.0.1:6071', 0);insert into perun.auditer_consumers (id, name, last_processed_id) values (nextval('auditer_consumers_id_seq'), 'ldapcConsumer', 0);insert into perun.auditer_consumers (id, name, last_processed_id) values (nextval('auditer_consumers_id_seq'), 'notifications', 0);";
-  when: table_users.rc == 1 or (table_users.rc == 0 and table_users.stdout == '0')
-
 - name: Create cron job for dumping data to a file usable for filesystem backup
   copy:
     dest: "/etc/cron.d/postgresql-backup"


### PR DESCRIPTION
- Initialization was moved to db init script and is part of
  "Create tables" task.
- Merge only after 3.9.0 release.