### PR TITLE
Added new config properties to limit group name for eduteams

### DIFF
--- a/roles/configuration-perun/templates/perun_properties.j2
+++ b/roles/configuration-perun/templates/perun_properties.j2
@@ -121,3 +121,7 @@ perun.autocreatedNamespaces=
 
 # Default JDBC query timeout for each preparedStatement (in seconds). Set to -1 for unlimited.
 # perun.queryTimeout=-1
+
+# Secondary regexes to limit group names
+#perun.group.nameSecondaryRegex=
+#perun.group.fullNameSecondaryRegex=

--- a/roles/configuration-perun/templates/perun_web_gui_properties.j2
+++ b/roles/configuration-perun/templates/perun_web_gui_properties.j2
@@ -18,6 +18,10 @@ getIdentityConsolidatorUrl=
 # Relevant to CESNET instance only
 gdprAdminEnabled=false
 
+# Regex and error message for group names in GUI.
+#groupNameSecondaryRegex=
+#groupNameErrorMessage=
+
 ### NEW WUI CONFIG ######
 
 rt.defaultQueue=perun


### PR DESCRIPTION
- At EduTEAMS they need more strict rules for group naming.
- Added secondary regex config in perun.properties.
- Added secondary regex config in perun-web-gui.properties