### PR TITLE
Support logging of groups synchronizations in separate files

### DIFF
--- a/roles/configuration-perun/templates/logback_xml.j2
+++ b/roles/configuration-perun/templates/logback_xml.j2
@@ -97,17 +97,25 @@
 		<appender-ref ref="perun-cabinet"/>
 	</logger>
 
-	<appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="perun-core">
-		<file>${LOGDIR}perun-core.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-			<fileNamePattern>${LOGDIR}perun-core.log.%d.%i</fileNamePattern>
-			<maxFileSize>100MB</maxFileSize>
-			<maxHistory>${MAXHISTORY}</maxHistory>
-			<totalSizeCap>1GB</totalSizeCap>
-		</rollingPolicy>
-		<encoder>
-			<pattern>${ENCODER_PATTERN}</pattern>
-		</encoder>
+	<appender name="perun-core" class="ch.qos.logback.classic.sift.SiftingAppender">
+		<discriminator>
+			<key>logFileName</key>
+			<defaultValue>perun-core</defaultValue>
+		</discriminator>
+		<sift>
+		<appender name="sift-${logFileName}" class="ch.qos.logback.core.rolling.RollingFileAppender">
+			<file>${LOGDIR}${logFileName}.log</file>
+			<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+				<fileNamePattern>${LOGDIR}${logFileName}.log.%d.%i</fileNamePattern>
+				<maxFileSize>100MB</maxFileSize>
+				<maxHistory>${MAXHISTORY}</maxHistory>
+				<totalSizeCap>1GB</totalSizeCap>
+			</rollingPolicy>
+			<encoder>
+				<pattern>${ENCODER_PATTERN}</pattern>
+			</encoder>
+		</appender>
+		</sift>
 	</appender>
 	<logger name="cz.metacentrum.perun.core" level="debug" additivity="false">
 		<appender-ref ref="perun-core"/>

--- a/roles/perun/tasks/Debian.yml
+++ b/roles/perun/tasks/Debian.yml
@@ -11,7 +11,7 @@
   group:
     name: "{{ perun_group }}"
     system: yes
-    
+
 - name: "Create {{ perun_login }} user"
   user:
     name: "{{ perun_login }}"
@@ -36,6 +36,15 @@
 - name: Make "{{ perun_log_dir }}" directory
   file:
     path: "{{ perun_log_dir }}"
+    state: directory
+    mode: 0775
+    owner: "{{ perun_login }}"
+    group: "{{ perun_group }}"
+
+# used for logs from group synchronizations
+- name: Make "{{ perun_log_dir }}/groupsync" directory
+  file:
+    path: "{{ perun_log_dir }}/groupsync"
     state: directory
     mode: 0775
     owner: "{{ perun_login }}"


### PR DESCRIPTION
- All perun-core logging for group synchronization threads
  will be redirected by using SIFT appender.